### PR TITLE
Use paket install instead of paket restore

### DIFF
--- a/fake.bat
+++ b/fake.bat
@@ -3,7 +3,7 @@
 set fake_args=%*
 
 cd "._fake"
-call "paket.bat" "restore"
+call "paket.bat" "install"
 cd ".."
 
 "._fake\packages\FAKE\tools\FAKE.exe" "build.fsx" %fake_args%


### PR DESCRIPTION
This way, it doesn't explode on the initial run because a paket.lock
file doesn't exist yet.
