### PR TITLE
Upgrade fs-fake-targets dep to v0.1.0

### DIFF
--- a/._fake/paket.dependencies
+++ b/._fake/paket.dependencies
@@ -2,4 +2,4 @@ source https://nuget.org/api/v2
 
 nuget fake
 nuget NUnit.Runners 2.6.4
-nuget FSharp.FakeTargets 0.1.0-beta
+nuget FSharp.FakeTargets 0.1.0

--- a/._fake/paket.lock
+++ b/._fake/paket.lock
@@ -2,5 +2,5 @@ NUGET
   remote: https://www.nuget.org/api/v2
   specs:
     FAKE (4.25.4)
-    FSharp.FakeTargets (0.1.0-beta)
+    FSharp.FakeTargets (0.1)
     NUnit.Runners (2.6.4)

--- a/build.fsx
+++ b/build.fsx
@@ -8,7 +8,7 @@ open NuGetHelper
 open RestorePackageHelper
 open datNET.Fake.Config
 
-datNET.Targets.Initialize id
+DatNET.Targets.Initialize id
 
 Target "RestorePackages" (fun _ ->
   Source.SolutionFile


### PR DESCRIPTION
The change in `build.fsx` is only temporary, as the namespace in fs-fake-targets v0.1.0 was `DatNET`, as opposed to `datNET`.
