### PR TITLE
Upgrade the fs-fake-targets dependency

### DIFF
--- a/._fake/paket.dependencies
+++ b/._fake/paket.dependencies
@@ -2,4 +2,4 @@ source https://nuget.org/api/v2
 
 nuget fake
 nuget NUnit.Runners 2.6.4
-nuget FSharp.FakeTargets 0.1.0
+nuget FSharp.FakeTargets 0.1.1

--- a/._fake/paket.lock
+++ b/._fake/paket.lock
@@ -2,5 +2,5 @@ NUGET
   remote: https://www.nuget.org/api/v2
   specs:
     FAKE (4.25.4)
-    FSharp.FakeTargets (0.1)
+    FSharp.FakeTargets (0.1.1)
     NUnit.Runners (2.6.4)

--- a/build.fsx
+++ b/build.fsx
@@ -8,7 +8,7 @@ open NuGetHelper
 open RestorePackageHelper
 open datNET.Fake.Config
 
-DatNET.Targets.Initialize id
+datNET.Targets.Initialize id
 
 Target "RestorePackages" (fun _ ->
   Source.SolutionFile


### PR DESCRIPTION
This allows us to use the proper namespace in `build.fsx`
