### PR TITLE
Upgrade AssemblyInfoUtils dep to 0.1.4

### DIFF
--- a/src/FSharpFakeTargets/FSharpFakeTargets.fsproj
+++ b/src/FSharpFakeTargets/FSharpFakeTargets.fsproj
@@ -61,7 +61,7 @@
       <HintPath>..\..\packages\FAKE.4.22.8\tools\FakeLib.dll</HintPath>
     </Reference>
     <Reference Include="FSharpAssemblyInfoUtils">
-      <HintPath>..\..\packages\FSharp.AssemblyVersion.Utils.0.1.3\tools\FSharpAssemblyInfoUtils.dll</HintPath>
+      <HintPath>..\..\packages\FSharp.AssemblyVersion.Utils.0.1.4\tools\FSharpAssemblyInfoUtils.dll</HintPath>
     </Reference>
     <Reference Include="FSharpFilePathUtils">
       <HintPath>..\..\packages\FSharp.FilePath.Utils.0.1.0\tools\FSharpFilePathUtils.dll</HintPath>

--- a/src/FSharpFakeTargets/packages.config
+++ b/src/FSharpFakeTargets/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FAKE" version="4.22.8" targetFramework="net452" />
-  <package id="FSharp.AssemblyVersion.Utils" version="0.1.3" targetFramework="net452" />
+  <package id="FSharp.AssemblyVersion.Utils" version="0.1.4" targetFramework="net452" />
   <package id="FSharp.FilePath.Utils" version="0.1.0" targetFramework="net452" />
   <package id="FSharp.Version.Utils" version="0.1.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
This means we can FINALLY use the increment-version targets without
having to worry about funky whitespace. This took way longer than I'm
happy to admit lol.
