### PR TITLE
Upgrade self dep

### DIFF
--- a/._fake/paket.lock
+++ b/._fake/paket.lock
@@ -2,5 +2,5 @@ NUGET
   remote: https://www.nuget.org/api/v2
   specs:
     FAKE (4.25.4)
-    FSharp.FakeTargets (0.4.2)
+    FSharp.FakeTargets (0.5)
     NUnit.Runners (2.6.4)

--- a/build.fsx
+++ b/build.fsx
@@ -25,16 +25,9 @@ Target "RestorePackages" (fun _ ->
   |> Seq.head
   |> RestoreMSSolutionPackages (fun p ->
       { p with
-          Sources = [ "https://nuget.org/api/v2"; ]
+          Sources = [ "https://nuget.org/api/v2" ]
           OutputPath = "packages"
           Retries = 4 })
-)
-
-Target "Test" (fun _ ->
-  let setParams = (fun p ->
-    { p with DisableShadowCopy = true; ErrorLevel = DontFailBuild; Framework = Build.DotNetVersion; })
-
-  Build.TestAssemblies |> NUnit setParams
 )
 
 "MSBuild"           <== [ "Clean"; "RestorePackages" ]


### PR DESCRIPTION
One thing to note is that this will fail on appveyor until https://github.com/datNET/fs-fake-targets/pull/51 has been merged and a corresponding nupkg has been published.
