### PR TITLE
Target .NET 4.5 and FSharp.Core 3.3.0

### DIFF
--- a/src/FSharpFakeTargets/FSharpFakeTargets.fsproj
+++ b/src/FSharpFakeTargets/FSharpFakeTargets.fsproj
@@ -9,10 +9,11 @@
     <OutputType>Library</OutputType>
     <RootNamespace>FSharpFakeTargets</RootNamespace>
     <AssemblyName>FSharpFakeTargets</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Name>FSharpFakeTargets</Name>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -61,15 +62,15 @@
       <HintPath>..\..\packages\FAKE.4.22.8\tools\FakeLib.dll</HintPath>
     </Reference>
     <Reference Include="FSharpAssemblyInfoUtils">
-      <HintPath>..\..\packages\FSharp.AssemblyVersion.Utils.0.2.0\lib\net45\FSharpAssemblyInfoUtils.dll</HintPath>
+      <HintPath>..\..\packages\FSharp.AssemblyVersion.Utils.0.2.1\lib\net45\FSharpAssemblyInfoUtils.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FSharpFilePathUtils">
-      <HintPath>..\..\packages\FSharp.FilePath.Utils.0.2.0\lib\net45\FSharpFilePathUtils.dll</HintPath>
+      <HintPath>..\..\packages\FSharp.FilePath.Utils.0.2.1\lib\net45\FSharpFilePathUtils.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FSharpVersionUtils">
-      <HintPath>..\..\packages\FSharp.Version.Utils.0.2.0\lib\net45\FSharpVersionUtils.dll</HintPath>
+      <HintPath>..\..\packages\FSharp.Version.Utils.0.2.1\lib\net45\FSharpVersionUtils.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib" />

--- a/src/FSharpFakeTargets/packages.config
+++ b/src/FSharpFakeTargets/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FAKE" version="4.22.8" targetFramework="net452" />
-  <package id="FSharp.AssemblyVersion.Utils" version="0.2.0" targetFramework="net452" />
-  <package id="FSharp.FilePath.Utils" version="0.2.0" targetFramework="net452" />
-  <package id="FSharp.Version.Utils" version="0.2.0" targetFramework="net452" />
+  <package id="FSharp.AssemblyVersion.Utils" version="0.2.1" targetFramework="net45" />
+  <package id="FSharp.FilePath.Utils" version="0.2.1" targetFramework="net45" />
+  <package id="FSharp.Version.Utils" version="0.2.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Following advice from [here](https://fsharp.github.io/2015/04/18/fsharp-core-notes.html)

> F# ecosystem libraries should generally target the earliest, most portable version of FSharp.Core feasible.
> 
> If your library is part of an ecosystem, it can be helpful to target the earliest, most widespread language version and the earliest (4.0+) and most portable profiles of the .NET Framework feasible.
