### PR TITLE
Remove DontFailBuild from NugetParams

### DIFF
--- a/src/FSharpFakeTargets/targets.fs
+++ b/src/FSharpFakeTargets/targets.fs
@@ -101,7 +101,6 @@ module Targets =
         let run = NUnit (fun p ->
           { p with
               DisableShadowCopy = true
-              ErrorLevel = DontFailBuild
               Framework = dotNET
           })
 


### PR DESCRIPTION
This was causing CI builds to show as successful even if tests failed.
We don't want that.

[See here for an example](https://ci.appveyor.com/project/datNET/fs-version-utils/build/1.0.143)
