### PR TITLE
Fix missing param behvaior in SetPrerelease

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -12,7 +12,7 @@
   done on the source code for FSharpFakeTargets without having to release or
   anything like that.
 *)
-//#r @"./src/FSharpFakeTargets/bin/Debug/FSharpFakeTargets.dll"
+// #r @"./src/FSharpFakeTargets/bin/Debug/FSharpFakeTargets.dll"
 
 #load @"./._fake/loader.fsx"
 

--- a/src/FSharpFakeTargets/targets.fs
+++ b/src/FSharpFakeTargets/targets.fs
@@ -183,7 +183,7 @@ module Targets =
       _CreateTarget "SetPrerelease:RootAssemblyInfo" parameters (fun _ ->
         let preStr =
           match getBuildParam "pre" with
-          | "" -> None
+          | "" -> invalidArg "pre" "Missing required parameter"
           | str -> Some str
 
         prereleaseTargetHelper preStr


### PR DESCRIPTION
Previously, calling the following would remove the `prerelease` version, essentially putting you in live-release mode when you may have just made a mistake... (Scary!)

```
.\fake.bat SetPrerelease:RootAssemblyInfo
```

Now, it just displays an error telling you that you are missing a required parameter!
Much safer!
Thanks @mglodack for the idea on this.
