### PR TITLE
Make error for unspecified nuspec in params clearer

### DIFF
--- a/src/FSharpFakeTargets/targets.fs
+++ b/src/FSharpFakeTargets/targets.fs
@@ -62,10 +62,11 @@ module Targets =
           traceError errorMessage
           exit 1
 
-  let private _ensureNuspecFileExists filePath =
+  let private _ensureNuspecFilepathProvided filePath =
     match filePath with
     | Some x -> x
-    | None -> raise (FileNotFoundException("Could not find the nuspec file"))
+    | None ->
+      raise (Exception("No nuspec file specified in datNET configuration"))
 
   let private _target name func parameters =
     Target name (fun _ -> func parameters)
@@ -111,7 +112,7 @@ module Targets =
 
   let private _packageTarget = _target "Package" (fun parameters ->
     parameters.NuspecFilePath
-      |> _ensureNuspecFileExists
+      |> _ensureNuspecFilepathProvided
       |> NuGetPack (_createNuGetParams parameters)
   )
 

--- a/src/FSharpFakeTargets/targets.fs
+++ b/src/FSharpFakeTargets/targets.fs
@@ -66,7 +66,8 @@ module Targets =
     match filePath with
     | Some x -> x
     | None ->
-      raise (Exception("No nuspec file specified in datNET configuration"))
+      let message = "No nuspec file specified in datNET configuration, and automatic detection failed"
+      raise (FileNotFoundException(message))
 
   let private _target name func parameters =
     Target name (fun _ -> func parameters)


### PR DESCRIPTION
The existing message seemed to imply that a file was not found, when
what is actually happening is that no nuspec filepath was ever even
specified in the datNET configuration parameters.
