### PR TITLE
Remove AssemblyInfoUtils from nuspec

### DIFF
--- a/FSharpFakeTargets.nuspec
+++ b/FSharpFakeTargets.nuspec
@@ -11,7 +11,6 @@
   </metadata>
   <files>
     <file src="FSharpFakeTargets.dll" target="tools" />
-    <file src="FSharpAssemblyInfoUtils.dll" target="tools" />
     <file src="FSharpFilePathUtils.dll" target="tools" />
     <file src="FSharpVersionUtils.dll" target="tools" />
   </files>


### PR DESCRIPTION
We no longer have that lib as a dependency, so that file won't be found
