### PR TITLE
Upgrade FAKE dependency

### DIFF
--- a/._fake/paket.lock
+++ b/._fake/paket.lock
@@ -1,6 +1,5 @@
 NUGET
   remote: https://www.nuget.org/api/v2
-  specs:
     FAKE (4.25.4)
     FSharp.FakeTargets (0.8)
     NUnit.Runners (2.6.4)

--- a/src/FSharpFakeTargets/FSharpFakeTargets.fsproj
+++ b/src/FSharpFakeTargets/FSharpFakeTargets.fsproj
@@ -59,7 +59,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FakeLib">
-      <HintPath>..\..\packages\FAKE.4.22.8\tools\FakeLib.dll</HintPath>
+      <HintPath>..\..\packages\FAKE.4.38.1\tools\FakeLib.dll</HintPath>
     </Reference>
     <Reference Include="FSharpFilePathUtils">
       <HintPath>..\..\packages\FSharp.FilePath.Utils.0.2.1\lib\net45\FSharpFilePathUtils.dll</HintPath>

--- a/src/FSharpFakeTargets/packages.config
+++ b/src/FSharpFakeTargets/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FAKE" version="4.22.8" targetFramework="net452" />
+  <package id="FAKE" version="4.38.1" targetFramework="net45" />
   <package id="FSharp.FilePath.Utils" version="0.2.1" targetFramework="net45" />
   <package id="FSharp.Version.Utils" version="0.3.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This was originally intended to help solve https://github.com/datNET/fs-fake-targets/issues/82

Now that I look at it, though, I'm not sure if this is necessarily the fix.
Since our FAKE dependency in the project was 4.22.8 at the time of this PR, but the issue reports that the broken FAKE dependency was at 4.14.2, it seems like the consuming project's FAKE dependency is the version that'll end up getting used at runtime...

Even so, it's probably not a bad idea to update the dependency.
