### PR TITLE
Add nuget package project file support

### DIFF
--- a/._fake/paket.lock
+++ b/._fake/paket.lock
@@ -1,5 +1,6 @@
 NUGET
   remote: https://www.nuget.org/api/v2
+  specs:
     FAKE (4.25.4)
     FSharp.FakeTargets (0.8)
     NUnit.Runners (2.6.4)

--- a/src/FSharpFakeTargets/FSharpFakeTargets.fsproj
+++ b/src/FSharpFakeTargets/FSharpFakeTargets.fsproj
@@ -52,6 +52,7 @@
   <Import Project="$(FSharpTargetsPath)" />
   <ItemGroup>
     <Content Include="packages.config" />
+    <Compile Include="validation.fs" />
     <Compile Include="targets.fs" />
     <Compile Include="..\..\AssemblyInfo.fs">
       <Link>AssemblyInfo.fs</Link>

--- a/src/FSharpFakeTargets/FSharpFakeTargets.nuspec
+++ b/src/FSharpFakeTargets/FSharpFakeTargets.nuspec
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <id>$id$</id>
+    <version>$version$</version>
+    <title>$title$</title>
+    <authors>Andrew Seward, Mathew Glodack</authors>
+    <owners>$author$</owners>
+    <projectUrl>https://github.com/datNET/fs-fake-targets</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>$description$</description>
+    <copyright>Copyright datNET 2016</copyright>
+  </metadata>
+</package>

--- a/src/FSharpFakeTargets/targets.fs
+++ b/src/FSharpFakeTargets/targets.fs
@@ -32,7 +32,7 @@ module Targets =
       Publish:                 bool
       AccessKey:               string
       PublishUrl:              string
-      Properties:              List<string * string>
+      Properties:              (string * string) list
       ProjectFilePath:         string option
     }
 
@@ -119,7 +119,8 @@ module Targets =
     |> NuGetPack (_createNuGetParams parameters)
   )
 
-  let private _packageFromNuspecTarget = _target "Package:Nuspec" (fun parameters ->
+  let private _packageFromNuspecTarget = _target "Package" (fun parameters ->
+    traceError "Warning: `Package` target will be renamed to `Package:Nuspec` in the next breaking version change."
     parameters.NuspecFilePath
     |> EnsureConfigPropertyFileExists "Nuspec file"
     |> NuGetPack (_createNuGetParams parameters)

--- a/src/FSharpFakeTargets/validation.fs
+++ b/src/FSharpFakeTargets/validation.fs
@@ -1,0 +1,21 @@
+﻿namespace datNET
+
+module Validations =
+    open System.IO
+
+    let private _configurationFailedMessage propertyName =
+        sprintf "No %s specified in datNET configuration, and automatic detection failed." propertyName
+
+    let private _raiseFileNotFoundException propertyName =
+        let errorMessage = _configurationFailedMessage propertyName
+        raise(FileNotFoundException(errorMessage))
+
+    let private _fileExists filePath propertyName =
+        match File.Exists(filePath) with
+        | true -> filePath
+        | false -> _raiseFileNotFoundException propertyName
+
+    let EnsureConfigPropertyFileExists propertyName configPropertyFilePath  =
+        match configPropertyFilePath with
+        | Some filePath -> _fileExists filePath propertyName
+        | None -> _raiseFileNotFoundException propertyName


### PR DESCRIPTION
### What's new?

Added nuget package support for project files.
### NOTE

If `Properties` doesn't have `(Configuration, Release)` then it will try to package in Debug mode as default. (Not what it should do by default IMO)
### Breaking Change

This would be consider a breaking change by renaming the `Package` target to `Package:Nuspec`
