### PR TITLE
Add NuGet.CommandLine paket dep

### DIFF
--- a/._fake/paket.dependencies
+++ b/._fake/paket.dependencies
@@ -3,3 +3,4 @@ source https://nuget.org/api/v2
 nuget fake
 nuget NUnit.Runners 2.6.4
 nuget FSharp.FakeTargets
+nuget NuGet.CommandLine 2.8.6

--- a/._fake/paket.lock
+++ b/._fake/paket.lock
@@ -1,6 +1,6 @@
 NUGET
   remote: https://www.nuget.org/api/v2
-  specs:
     FAKE (4.25.4)
     FSharp.FakeTargets (0.8)
+    NuGet.CommandLine (2.8.6)
     NUnit.Runners (2.6.4)


### PR DESCRIPTION
### Why add a paket dependency?

This is a temporary fix to support an older version of the NuGet CLI that works as intended.
There was a breaking change somewhere with NuGet CLI where it is unable to find the default sources.
### Relevant GitHub conversations
1. https://github.com/NuGet/Home/issues/3066
2. https://github.com/NuGet/Home/issues/2288
### Follow up steps
1. Just awaiting this version to be stable. https://www.nuget.org/packages/NuGet.CommandLine/3.4.4-rtm-final
2. #91
