### PR TITLE
Fix package from nuspec incorrect function call

### DIFF
--- a/src/FSharpFakeTargets/targets.fs
+++ b/src/FSharpFakeTargets/targets.fs
@@ -127,18 +127,21 @@ module Targets =
     |> NuGetPack (_createNuGetParams parameters)
   )
 
-  let private _packageFromNuspecTarget = _target "Package:Nuspec" (fun parameters ->
+  let private _packFromNuspec parameters =
     parameters.NuspecFilePath
     |> EnsureConfigPropertyFileExists "Nuspec file"
     |> NuGetPack (_createNuGetParams parameters)
+
+  let private _packageFromNuspecTarget = _target "Package:Nuspec" (fun parameters ->
+    parameters
+    |> _packFromNuspec
   )
 
   [<Obsolete("Please use `_packageFromNuspecTarget`.")>]
   let private _obsoletePackageNuspecTarget = _target "Package" (fun parameters ->
     _displayWarningMessage "Warning: `Package` target will be renamed to `Package:Nuspec` in the next breaking version change."
     parameters
-    |> _packageFromNuspecTarget
-    |> ignore
+    |> _packFromNuspec
   )
 
   let private _publishTarget = _target "Publish" (fun parameters ->


### PR DESCRIPTION
### NOTE:

What was previously being called in `0.10.0` exposed a breaking change that wouldn't allow the `Package` Target to be ran. 

See here. https://github.com/datNET/fs-fake-targets/compare/fix_wrong_function_call?expand=1#diff-9941b4d16ae45047a277124621e7249aL140
### What can be done to prevent this?

Find a way to test these targets and their expected output. 
