### PR TITLE
Increment FakeTargets To PreRelease

### DIFF
--- a/._fake/loader.fsx
+++ b/._fake/loader.fsx
@@ -1,5 +1,5 @@
 #r    @"packages/FAKE/tools/FakeLib.dll"
-#r    @"packages/FSharp.FakeTargets/tools/FSharpFakeTargets.dll"
+#r    @"packages/FSharp.FakeTargets/lib/net45/FSharp.FakeTargets.dll"
 (*
   The commented line below is for local testing purposes. Make sure to
 

--- a/._fake/paket.dependencies
+++ b/._fake/paket.dependencies
@@ -2,5 +2,5 @@ source https://nuget.org/api/v2
 
 nuget fake 4.40
 nuget NUnit.Runners 2.6.4
-nuget FSharp.FakeTargets
+nuget FSharp.FakeTargets 0.10.2-alpha
 nuget NuGet.CommandLine 3.4.4-rtm-final

--- a/._fake/paket.lock
+++ b/._fake/paket.lock
@@ -1,6 +1,11 @@
 NUGET
   remote: https://www.nuget.org/api/v2
     FAKE (4.40)
-    FSharp.FakeTargets (0.10.1)
+    FSharp.FakeTargets (0.10.2-alpha)
+      FAKE (>= 4.38.1)
+      FSharp.FilePath.Utils (>= 0.2.1)
+      FSharp.Version.Utils (>= 0.3)
+    FSharp.FilePath.Utils (0.2.1)
+    FSharp.Version.Utils (0.3)
     NuGet.CommandLine (3.4.4-rtm-final)
     NUnit.Runners (2.6.4)


### PR DESCRIPTION
### NOTE

Since we're building our nuget package from a combination of `.nuspec` and `.fsproj` there is a slight change in the format of the nuget package.

Instead of the `.dll`s living under the `tools` path, they now lives under `lib/net45`.

### Resources 

Using the standard nuget conventions found here.

https://docs.nuget.org/ndocs/create-packages/creating-a-package#from-a-convention-based-working-directory