### PR TITLE
Add Package From Nuspec Target

### DIFF
--- a/src/FSharpFakeTargets/targets.fs
+++ b/src/FSharpFakeTargets/targets.fs
@@ -233,6 +233,7 @@ module Targets =
     |> _msBuildTarget
     |> _cleanTarget
     |> _obsoletePackageNuspecTarget
+    |> _packageFromNuspecTarget
     |> _packageFromProjectTarget
     |> _testTarget
     |> _publishTarget


### PR DESCRIPTION
### What's new?

In order to shim over from `Package` to `Package:Nuspec` they will both exist until the next breaking version change.

### NOTE

These do not expose any break change. They are both wrapping an existing function under the hood.