### PR TITLE
Provide Default PublishUrl

### DIFF
--- a/src/FSharpFakeTargets/targets.fs
+++ b/src/FSharpFakeTargets/targets.fs
@@ -53,7 +53,7 @@ module Targets =
       WorkingDir              = String.Empty
       Publish                 = false
       AccessKey               = String.Empty
-      PublishUrl              = String.Empty
+      PublishUrl              = "https://api.nuget.org/v3/index.json"
       Properties              = [ ("Configuration", "Release") ]
       ProjectFilePath         = None
     }


### PR DESCRIPTION
Pass through the default nuget url instead of an empty string.