### PR TITLE
Update self-dependency

### DIFF
--- a/._fake/paket.lock
+++ b/._fake/paket.lock
@@ -1,6 +1,6 @@
 NUGET
   remote: https://www.nuget.org/api/v2
     FAKE (4.60)
-    FSharp.FakeTargets (0.11)
+    FSharp.FakeTargets (0.11.1)
     NuGet.CommandLine (3.5)
     NUnit.Runners (2.6.4)

--- a/build.fsx
+++ b/build.fsx
@@ -13,7 +13,6 @@ let private _overrideConfig (parameters : datNET.Targets.ConfigParams) =
       OutputPath  = Release.OutputPath
       Publish     = true
       AccessKey   = Nuget.ApiKey
-      PublishUrl  = "https://www.nuget.org/api/v2/package"
       ProjectFilePath = Some("src/FSharpFakeTargets/FSharp.FakeTargets.fsproj")
       NuspecFilePath = Some(Release.Nuspec)
   }


### PR DESCRIPTION
Allows us to no longer need to specify a publishurl in build scripts